### PR TITLE
Add 'date' param to Ranking query

### DIFF
--- a/src/DexQuiz.Core/Interfaces/Services/IRankingService.cs
+++ b/src/DexQuiz.Core/Interfaces/Services/IRankingService.cs
@@ -1,16 +1,15 @@
 ﻿using DexQuiz.Core.Entities;
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace DexQuiz.Core.Interfaces.Services
 {
     public interface IRankingService
     {
-        Task<IEnumerable<TrackRanking>> GetPublicTrackRankingsAsync(int trackId, int? top = null);
-        Task<IEnumerable<TrackRanking>> GetTrackRankingsForAdminAsync(int trackId, int? top = null);
-        Task<IEnumerable<TrackRanking>> GetTrackRankingsForUserAsync(int trackId, int userId, int? top = null);
+        Task<IEnumerable<TrackRanking>> GetPublicTrackRankingsAsync(int trackId, int? top = null, DateTime? date = null);
+        Task<IEnumerable<TrackRanking>> GetTrackRankingsForAdminAsync(int trackId, int? top = null, DateTime? date = null);
+        Task<IEnumerable<TrackRanking>> GetTrackRankingsForUserAsync(int trackId, int userId, int? top = null, DateTime? date = null);
         Task InitializeRankingIfNotCreatedAsync(int userId, int trackId);
         Task UpdateRankingAfterUserAnswerAsync(AnsweredQuestion answeredQuestion);
     }

--- a/src/DexQuiz.Core/Services/RankingService.cs
+++ b/src/DexQuiz.Core/Services/RankingService.cs
@@ -115,7 +115,7 @@ namespace DexQuiz.Core.Services
         {
             IEnumerable<TrackRanking> trackRankings = null;
             if (date.HasValue)
-                trackRankings = await _trackRankingRepository.FindAsync(r => r.TrackId == trackId && r.CompletedTime != null && r.StartedAtUtc.Date == date); 
+                trackRankings = await _trackRankingRepository.FindAsync(r => r.TrackId == trackId && r.CompletedTime != null && r.StartedAtUtc.Date == date.Value.Date);
             else
                 trackRankings = await _trackRankingRepository.FindAsync(r => r.TrackId == trackId && r.CompletedTime != null);
 

--- a/src/DexQuiz.Core/Services/RankingService.cs
+++ b/src/DexQuiz.Core/Services/RankingService.cs
@@ -5,7 +5,6 @@ using DexQuiz.Core.Interfaces.UoW;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace DexQuiz.Core.Services
@@ -36,20 +35,20 @@ namespace DexQuiz.Core.Services
             _questionService = questionService;
         }
 
-        public async Task<IEnumerable<TrackRanking>> GetPublicTrackRankingsAsync(int trackId, int? top = null) =>
-            (await GetOrderedTrackRankingsAsync(trackId))
+        public async Task<IEnumerable<TrackRanking>> GetPublicTrackRankingsAsync(int trackId, int? top = null, DateTime? date = null) =>
+            (await GetOrderedTrackRankingsAsync(trackId, date))
             .Take(top ?? DefaultNumberOfRankingsFetched)
             .Select(MapTrackRankingWithoutUserInfo);
 
-        public async Task<IEnumerable<TrackRanking>> GetTrackRankingsForAdminAsync(int trackId, int? top = null) =>
-            (await GetOrderedTrackRankingsAsync(trackId))
+        public async Task<IEnumerable<TrackRanking>> GetTrackRankingsForAdminAsync(int trackId, int? top = null, DateTime? date = null) =>
+            (await GetOrderedTrackRankingsAsync(trackId, date))
             .Take(top ?? DefaultNumberOfRankingsFetched)
             .Select(async tr => await MapTrackRankingWithUserInfo(tr))
             .Select(tr => tr.Result);
 
-        public async Task<IEnumerable<TrackRanking>> GetTrackRankingsForUserAsync(int trackId, int userId, int? top = null)
+        public async Task<IEnumerable<TrackRanking>> GetTrackRankingsForUserAsync(int trackId, int userId, int? top = null, DateTime? date = null)
         {
-            var trackRankings = await GetOrderedTrackRankingsAsync(trackId);
+            var trackRankings = await GetOrderedTrackRankingsAsync(trackId, date);
             var topRankings = trackRankings.Take(top ?? DefaultNumberOfRankingsFetched);
             var userTrackRanking = trackRankings.FirstOrDefault(tr => tr.UserId == userId);
 
@@ -112,11 +111,18 @@ namespace DexQuiz.Core.Services
             }
         }
 
-        private async Task<IEnumerable<TrackRanking>> GetOrderedTrackRankingsAsync(int trackId) =>
-            (await _trackRankingRepository.FindAsync(r => r.TrackId == trackId && r.CompletedTime != null))
-                                              .OrderByDescending(r => r.Points)
-                                              .ThenBy(r => r.CompletedTime)
-                                              .Select(MapTrackRankingInsertingPosition);
+        private async Task<IEnumerable<TrackRanking>> GetOrderedTrackRankingsAsync(int trackId, DateTime? date)
+        {
+            IEnumerable<TrackRanking> trackRankings = null;
+            if (date.HasValue)
+                trackRankings = await _trackRankingRepository.FindAsync(r => r.TrackId == trackId && r.CompletedTime != null && r.StartedAtUtc.Date == date); 
+            else
+                trackRankings = await _trackRankingRepository.FindAsync(r => r.TrackId == trackId && r.CompletedTime != null);
+
+            return trackRankings.OrderByDescending(r => r.Points)
+                                .ThenBy(r => r.CompletedTime)
+                                .Select(MapTrackRankingInsertingPosition);
+        }
 
         private async Task<TrackRanking> MapTrackRankingWithUserInfo(TrackRanking trackRanking) =>
             new TrackRanking()

--- a/src/DexQuiz.Server/Controllers/RankingController.cs
+++ b/src/DexQuiz.Server/Controllers/RankingController.cs
@@ -42,10 +42,12 @@ namespace DexQuiz.Server.Controllers
         /// </summary>
         /// <param name="trackId">Track id</param>
         /// <param name="top">Number of ranking positions to be fetched</param>
+        /// <param name="date">Date to filter ranking for a specific day</param>
         /// <response code="200">Returns the ranking</response>
         [HttpGet("track/{trackId}")]
         public async Task<IActionResult> GetTrackRankings(int trackId,
-                                              [FromQuery(Name = "top")] int? top = null)
+                                                            [FromQuery(Name = "top")] int? top = null,
+                                                            [FromQuery(Name = "date")] DateTime? date = null)
         {
             // TODO: Usar cache para rankings públicos?
             bool isUserAdmin = this.IsLoggedUserAdmin();
@@ -53,9 +55,9 @@ namespace DexQuiz.Server.Controllers
 
             var trackRankings = (isUserAdmin, userId) switch
             {
-                (_, null) => await _rankingService.GetPublicTrackRankingsAsync(trackId, top),
-                (true, _) => await _rankingService.GetTrackRankingsForAdminAsync(trackId, top),
-                (false, _) => await _rankingService.GetTrackRankingsForUserAsync(trackId, (int)userId, top)
+                (_, null) => await _rankingService.GetPublicTrackRankingsAsync(trackId, top, date),
+                (true, _) => await _rankingService.GetTrackRankingsForAdminAsync(trackId, top, date),
+                (false, _) => await _rankingService.GetTrackRankingsForUserAsync(trackId, (int)userId, top, date)
             };
 
             return Ok(_mapper.Map<TrackRankingModel[]>(trackRankings));


### PR DESCRIPTION
This commit solves the problem of fetching all TrackRankings when
the user wants to see only the ranking of one day.

Resolves #11 